### PR TITLE
Use exact commit hashes when writing configuration file.

### DIFF
--- a/installSynApps/data_model/install_module.py
+++ b/installSynApps/data_model/install_module.py
@@ -47,6 +47,7 @@ class InstallModule:
 
         self.name       = name
         self.version    = version
+        self.exact_hash = None
         self.rel_path   = rel_path
         self.abs_path   = None
         self.url_type   = url_type

--- a/installSynApps/driver/clone_driver.py
+++ b/installSynApps/driver/clone_driver.py
@@ -172,6 +172,13 @@ class CloneDriver:
                         proc.wait()
                         ret = proc.returncode
 
+                    # Retrieve commit hash of checked out module for exact versioning
+                    command = 'git rev-parse --short HEAD'
+                    LOG.print_command(command)
+                    proc = Popen(command.split(' '), stdout=PIPE)
+                    out = proc.communicate().decode('utf-8')
+                    module.exact_hash = out
+
                     os.chdir(current_loc)
                     if ret == 0:
                         LOG.write('Checked out version {}'.format(module.version))

--- a/installSynApps/driver/packager_driver.py
+++ b/installSynApps/driver/packager_driver.py
@@ -25,6 +25,7 @@ import installSynApps.data_model.install_config as IC
 import installSynApps.io.logger as LOG
 import installSynApps.io.file_generator as FILE_GENERATOR
 import installSynApps.io.ioc_generator as IOC_GENERATOR
+import installSynApps.io.config_writer as CONFIG_WRITER
 
 
 class Packager:
@@ -563,6 +564,11 @@ class Packager:
         if os.path.exists(bundle_top):
             shutil.rmtree(bundle_top)    
         os.mkdir(bundle_top)
+
+        # Make sure we write the install configuration with the output tarball.
+        build_config_path = installSynApps.join_path(install_loc, 'build-config')
+        config_writer = CONFIG_WRITER.ConfigWriter(self.install_config)
+        config_writer.write_install_config(build_config_path)
 
         readme_path = installSynApps.join_path(readme_loc, readme_name)
         self.grab_base(bundle_top, include_src=with_sources, flat_grab=flat_output)

--- a/installSynApps/io/config_writer.py
+++ b/installSynApps/io/config_writer.py
@@ -161,7 +161,10 @@ class ConfigWriter:
             if module.url != current_url:
                 new_install_config.write("\n{}={}\n\n".format(module.url_type, module.url))
                 current_url = module.url
-            new_install_config.write("{:<16} {:<20} {:<40} {:<24} {:<16} {:<16} {}\n".format(module.name, module.version, module.rel_path, module.rel_repo, module.clone, module.build, module.package))
+            ver_to_write = module.version
+            if module.exact_hash is not None:
+                ver_to_write = module.exact_hash
+            new_install_config.write("{:<16} {:<20} {:<40} {:<24} {:<16} {:<16} {}\n".format(module.name, ver_to_write, module.rel_path, module.rel_repo, module.clone, module.build, module.package))
 
         new_install_config.close()
         return True, None


### PR DESCRIPTION
As discussed, extract the exact commit hash of the HEAD of the repo checked out at build time. Also, include the build-config with every output option (tarball, flat installation, etc.)

TODO: Add option to convert a configuration to exact commit hashes without running a clone/build.